### PR TITLE
Fix unnecessary check of private user profile content

### DIFF
--- a/instaRaider.py
+++ b/instaRaider.py
@@ -128,8 +128,7 @@ class InstaRaider(object):
         except NoSuchElementException:
             pass
         else:
-            if el.text.lower() == 'this account is private':
-                self.log_in_user()
+            self.log_in_user()
 
         if (num_to_download > 24):
             scroll_to_bottom = self.get_scroll_count(num_to_download)


### PR DESCRIPTION
I don't think it's necessary to check the actual text content of the "Profile is private" warning that is shown in the browser?  As long as the warning actually exists on the page, we know the profile in question is private. This fixes private profiles on non-english browsers, and closes #21.
